### PR TITLE
Recurse upwards if the appropriate function was shadowed by another

### DIFF
--- a/features/toggle-focus.feature
+++ b/features/toggle-focus.feature
@@ -30,6 +30,20 @@ Feature: Toggle focus
     And I should not see "iit("
     And the cursor should be before "expect"
 
+  Scenario: Focus a test with intermediate function call
+    When I insert:
+    """
+    describe('my jasminejs tests', function () {
+      it('should focus this test', function () {
+        barit('a troublesome function call');
+        expect(true).toBe(true);
+      });
+    });
+    """
+    And I go to the front of the word "expect"
+    And I press "C-c j it"
+    Then I should see "iit("
+    And the cursor should be before "expect"
 
   Scenario: Focus a collection with ddescribe
     When I insert:

--- a/jasminejs-mode.el
+++ b/jasminejs-mode.el
@@ -52,17 +52,19 @@ This is useful for toggling between an xdescribe and a ddescribe, for example."
   (let* ((word-regex (concat word "\w*("))
          (toggle-word (concat toggle-char word)))
     (save-excursion
-      (if (re-search-backward word-regex (point-min) 'no-error)
-          (progn
-            (beginning-of-line-text)
-            (if remove-char
-                (when (looking-at (concat remove-char word))
-                  (delete-char (length remove-char))))
-            (when (looking-at word)
-              (insert toggle-char))
-            (when (looking-at toggle-word)
-              (delete-char (length toggle-char))))
-        (message "I could not find '%s'" word)))))
+      (cl-labels ((helper ()
+			  (when (re-search-backward word-regex (point-min) t)
+			    (beginning-of-line-text)
+			    (if remove-char
+				(if (looking-at (concat remove-char word))
+				    (delete-char (length remove-char))
+				  (helper))
+			      (helper))
+			    (if (looking-at word)        (insert toggle-char) 
+			      (helper))
+			    (if (looking-at toggle-word) (delete-char (length toggle-char))
+			      (helper)))))
+	(helper)))))
 
 (defvar jasminejs-mode-map (make-sparse-keymap)
   "Jasminejs keymap")


### PR DESCRIPTION
Added a test which caused a problem for the 'it' and 'describe' function-call finder function.

It basically recurses upwards if the backwards regex search thinks if finds it, but is actually a similar-ending function call name.

For example a call to a 'somefunctionit' with the 'it' at the end would shadow the jasmine it call
