### PR TITLE
Use package-file directive in Cask

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,6 +1,6 @@
 (source melpa)
 
-(package "jasminejs-mode" "0.1.0" "Manipulate jasmine js files")
+(package-file "jasminejs-mode.el")
 
 (development
  (depends-on "ecukes")


### PR DESCRIPTION
This avoids duplication of metadata between Cask and jasminejs-mode.el.

(In connection with https://github.com/milkypostman/melpa/pull/2326)
